### PR TITLE
make variables work in '@preprocessor stylus' mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-watch": "1.1.0",
     "grunt-sass": "3.1.0",
-    "node-sass": "^5.0.0"
+    "node-sass": "^9.0.0"
   }
 }

--- a/src/build.scss
+++ b/src/build.scss
@@ -35,7 +35,7 @@
 
 @-moz-document __DOMAINS__ {
 	:root {
-		--max-col-width: var(--mainColumnMaxWidth,720px);
+		--max-col-width: mainColumnMaxWidth;
 
 		--font-family-sans: sans-serif;
 		--font-family-serif: serif;

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -10,26 +10,26 @@ Default
 	if theme == default {
 
 		:root {
-			--max-col-width: var(--mainColumnMaxWidth,720px);
+			--max-col-width: mainColumnMaxWidth;
 
 			--font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
 			--font-family-serif: Georgia,serif;
 			--font-heading: var(--font-family-sans);
 
-			--main-bg: var(--liteModeBackgroundColor, #fbf3e9);
+			--main-bg: liteModeBackgroundColor;
 
-			--primary-text: var(--liteModePrimaryText, #3B3833);
+			--primary-text: liteModePrimaryText;
 				--light-text: #867d73;
 				--faint-text: #aaa29a;
-				--heading-text: var(--liteModeHeadingText, #393735);
+				--heading-text: liteModeHeadingText;
 
 			--horizontal-rule-border-bottom-props: 2px solid rgba(0, 0, 0, .25);
 			--end-horizontal-rule-border-bottom-props: 5px solid #000;
 
-			--link: var(--liteModeLinkColor, #1780CF);
-			--link-hover: var(--liteModeLinkHoverColor, #0091FF);
-			--link-visited: var(--liteModeLinkVisitedColor, #625A9E);
-			--link-active: var(--liteModeLinkHoverColor, #0091FF);				
+			--link: liteModeLinkColor;
+			--link-hover: liteModeLinkHoverColor;
+			--link-visited: liteModeLinkVisitedColor;
+			--link-active: liteModeLinkHoverColor;
 
 			--image-shadow: none;
 			--image-border-props: 1px solid #000;
@@ -86,17 +86,17 @@ Default
 
 	@media (prefers-color-scheme: dark) {
 		:root {
-			--main-bg: var(--darkModeBackgroundColor, #181C23);
+			--main-bg: darkModeBackgroundColor;
 
-			--primary-text: var(--darkModePrimaryText, #E3EDFD);
+			--primary-text: darkModePrimaryText;
 				--light-text: #a3aebf;
 				--faint-text: #4d5563;
-				--heading-text: var(--darkModeHeadingText, rgba(255,255,255,.9));
+				--heading-text: darkModeHeadingText;
 
-			--link: var(--darkModeLinkColor, #0091FF);
-			--link-hover: var(--darkModeLinkHoverColor, #66bdff);
-			--link-visited: var(--darkModeLinkVisitedColor, #A078FF);
-			--link-active: var(--darkModeLinkActiveColor, #A078FF);
+			--link: darkModeLinkColor;
+			--link-hover: darkModeLinkHoverColor;
+			--link-visited: darkModeLinkVisitedColor;
+			--link-active: darkModeLinkActiveColor;
 
 			--input-border: 1px solid rgba(255,255,255,.5);
 			--input-border-focus: 1px solid var(--link);

--- a/style.user.css
+++ b/style.user.css
@@ -41,7 +41,7 @@
 ==/UserStyle== */
 @-moz-document domain("marxists.org"),domain("marxists.info"),domain("marxists.architexturez.net") {
   :root {
-    --max-col-width: var(--mainColumnMaxWidth,720px);
+    --max-col-width: mainColumnMaxWidth;
     --font-family-sans: sans-serif;
     --font-family-serif: serif;
     --font-heading: sans-serif;
@@ -1157,26 +1157,26 @@ Default
  if theme == default {
 
   :root {
-   --max-col-width: var(--mainColumnMaxWidth,720px);
+   --max-col-width: mainColumnMaxWidth;
 
    --font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
    --font-family-serif: Georgia,serif;
    --font-heading: var(--font-family-sans);
 
-   --main-bg: var(--liteModeBackgroundColor, #fbf3e9);
+   --main-bg: liteModeBackgroundColor;
 
-   --primary-text: var(--liteModePrimaryText, #3B3833);
+   --primary-text: liteModePrimaryText;
     --light-text: #867d73;
     --faint-text: #aaa29a;
-    --heading-text: var(--liteModeHeadingText, #393735);
+    --heading-text: liteModeHeadingText;
 
    --horizontal-rule-border-bottom-props: 2px solid rgba(0, 0, 0, .25);
    --end-horizontal-rule-border-bottom-props: 5px solid #000;
 
-   --link: var(--liteModeLinkColor, #1780CF);
-   --link-hover: var(--liteModeLinkHoverColor, #0091FF);
-   --link-visited: var(--liteModeLinkVisitedColor, #625A9E);
-   --link-active: var(--liteModeLinkHoverColor, #0091FF);    
+   --link: liteModeLinkColor;
+   --link-hover: liteModeLinkHoverColor;
+   --link-visited: liteModeLinkVisitedColor;
+   --link-active: liteModeLinkHoverColor;
 
    --image-shadow: none;
    --image-border-props: 1px solid #000;
@@ -1233,17 +1233,17 @@ Default
 
  @media (prefers-color-scheme: dark) {
   :root {
-   --main-bg: var(--darkModeBackgroundColor, #181C23);
+   --main-bg: darkModeBackgroundColor;
 
-   --primary-text: var(--darkModePrimaryText, #E3EDFD);
+   --primary-text: darkModePrimaryText;
     --light-text: #a3aebf;
     --faint-text: #4d5563;
-    --heading-text: var(--darkModeHeadingText, rgba(255,255,255,.9));
+    --heading-text: darkModeHeadingText;
 
-   --link: var(--darkModeLinkColor, #0091FF);
-   --link-hover: var(--darkModeLinkHoverColor, #66bdff);
-   --link-visited: var(--darkModeLinkVisitedColor, #A078FF);
-   --link-active: var(--darkModeLinkActiveColor, #A078FF);
+   --link: darkModeLinkColor;
+   --link-hover: darkModeLinkHoverColor;
+   --link-visited: darkModeLinkVisitedColor;
+   --link-active: darkModeLinkActiveColor;
 
    --input-border: 1px solid rgba(255,255,255,.5);
    --input-border-focus: 1px solid var(--link);


### PR DESCRIPTION


The variables don't work with `@preprocessor     stylus`. In `stylus` mode, `var(--variableName, defaultValue)` always resolves to `defaultValue`, rendering the variables ineffective.

I have replaced all instances with the correct usage.